### PR TITLE
:sparkles: Add support for mods in AlfredItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.12
+- Add support for mods field in AlfredItem
+
 ## 0.2.11
 - Updated dependencies
 - Rebuilt generated files

--- a/lib/src/models/alfred_item.dart
+++ b/lib/src/models/alfred_item.dart
@@ -1,3 +1,4 @@
+import 'package:alfred_workflow/src/models/alfred_item_mod.dart';
 import 'package:autoequal/autoequal.dart';
 import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:equatable/equatable.dart' show EquatableMixin;
@@ -28,6 +29,7 @@ class AlfredItem with EquatableMixin, _$AlfredItemAutoequalMixin {
     this.text,
     this.quickLookUrl,
     this.match,
+    this.mods,
   });
 
   /// The [title] displayed in the result row. There are no options for this element and it is essential that this element is populated.
@@ -103,6 +105,12 @@ class AlfredItem with EquatableMixin, _$AlfredItemAutoequalMixin {
   @JsonKey(includeIfNull: false)
   final String? match;
 
+  /// The [mods] give you control over how the modifier keys react.
+  ///
+  /// It can alter the looks of a result (e.g. subtitle, icon) and output a different arg or session variables.
+  @JsonKey(includeIfNull: false, toJson: _modsToJson, fromJson: _modsFromJson)
+  final Map<Set<AlfredItemModKey>, AlfredItemMod>? mods;
+
   static AlfredItemIcon? _iconFromJson(dynamic icon) => icon == null
       ? null
       : AlfredItemIcon.fromJson(Map<String, dynamic>.from(icon));
@@ -110,6 +118,30 @@ class AlfredItem with EquatableMixin, _$AlfredItemAutoequalMixin {
   static AlfredItemText? _textFromJson(dynamic text) => text == null
       ? null
       : AlfredItemText.fromJson(Map<String, dynamic>.from(text));
+
+  static Map<String, Map<String, dynamic>>? _modsToJson(
+    Map<Set<AlfredItemModKey>, AlfredItemMod>? mods,
+  ) =>
+      mods?.map(
+        (Set<AlfredItemModKey> key, AlfredItemMod value) => MapEntry(
+          key.map((AlfredItemModKey k) => k.name).join('+'),
+          value.toJson(),
+        ),
+      );
+
+  static Map<Set<AlfredItemModKey>, AlfredItemMod>? _modsFromJson(Map? mods) {
+    if (mods == null) return null;
+
+    return Map<String, dynamic>.from(mods).map(
+      (String key, dynamic value) => MapEntry(
+        key
+            .split('+')
+            .map((String k) => AlfredItemModKey.values.byName(k))
+            .toSet(),
+        AlfredItemMod.fromJson(Map<String, dynamic>.from(value)),
+      ),
+    );
+  }
 
   factory AlfredItem.fromJson(Map<String, dynamic> json) =>
       _$AlfredItemFromJson(json);

--- a/lib/src/models/alfred_item.g.dart
+++ b/lib/src/models/alfred_item.g.dart
@@ -23,7 +23,8 @@ extension _$AlfredItemAutoequal on AlfredItem {
         icon,
         text,
         quickLookUrl,
-        match
+        match,
+        mods
       ];
 }
 
@@ -54,6 +55,8 @@ abstract class _$AlfredItemCWProxy {
 
   AlfredItem match(String? match);
 
+  AlfredItem mods(Map<Set<AlfredItemModKey>, AlfredItemMod>? mods);
+
   /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `AlfredItem(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
   ///
   /// Usage
@@ -72,6 +75,7 @@ abstract class _$AlfredItemCWProxy {
     AlfredItemText? text,
     String? quickLookUrl,
     String? match,
+    Map<Set<AlfredItemModKey>, AlfredItemMod>? mods,
   });
 }
 
@@ -117,6 +121,10 @@ class _$AlfredItemCWProxyImpl implements _$AlfredItemCWProxy {
   AlfredItem match(String? match) => this(match: match);
 
   @override
+  AlfredItem mods(Map<Set<AlfredItemModKey>, AlfredItemMod>? mods) =>
+      this(mods: mods);
+
+  @override
 
   /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `AlfredItem(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
   ///
@@ -136,6 +144,7 @@ class _$AlfredItemCWProxyImpl implements _$AlfredItemCWProxy {
     Object? text = const $CopyWithPlaceholder(),
     Object? quickLookUrl = const $CopyWithPlaceholder(),
     Object? match = const $CopyWithPlaceholder(),
+    Object? mods = const $CopyWithPlaceholder(),
   }) {
     return AlfredItem(
       title: title == const $CopyWithPlaceholder() || title == null
@@ -185,6 +194,10 @@ class _$AlfredItemCWProxyImpl implements _$AlfredItemCWProxy {
           ? _value.match
           // ignore: cast_nullable_to_non_nullable
           : match as String?,
+      mods: mods == const $CopyWithPlaceholder()
+          ? _value.mods
+          // ignore: cast_nullable_to_non_nullable
+          : mods as Map<Set<AlfredItemModKey>, AlfredItemMod>?,
     );
   }
 }
@@ -216,6 +229,7 @@ AlfredItem _$AlfredItemFromJson(Map<String, dynamic> json) {
     text: AlfredItem._textFromJson(json['text']),
     quickLookUrl: json['quicklookurl'] as String?,
     match: json['match'] as String?,
+    mods: AlfredItem._modsFromJson(json['mods'] as Map?),
   );
 }
 
@@ -240,5 +254,6 @@ Map<String, dynamic> _$AlfredItemToJson(AlfredItem instance) {
   writeNotNull('text', instance.text?.toJson());
   writeNotNull('quicklookurl', instance.quickLookUrl);
   writeNotNull('match', instance.match);
+  writeNotNull('mods', AlfredItem._modsToJson(instance.mods));
   return val;
 }

--- a/lib/src/models/alfred_item_mod.dart
+++ b/lib/src/models/alfred_item_mod.dart
@@ -1,0 +1,59 @@
+import 'package:alfred_workflow/src/models/alfred_item_icon.dart';
+import 'package:autoequal/autoequal.dart';
+import 'package:copy_with_extension/copy_with_extension.dart';
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'alfred_item_mod.g.dart';
+
+enum AlfredItemModKey {
+  @JsonValue('cmd')
+  cmd,
+  @JsonValue('ctrl')
+  ctrl,
+  @JsonValue('alt')
+  alt,
+  @JsonValue('shift')
+  shift,
+  @JsonValue('fn')
+  fn,
+}
+
+/// The [AlfredItemMod] gives you control over how the modifier keys react.
+///
+/// It can alter the looks of a result (e.g. [subtitle], [icon]) and output a different [arg].
+@autoequalMixin
+@CopyWith()
+@JsonSerializable(explicitToJson: true)
+class AlfredItemMod with EquatableMixin, _$AlfredItemModAutoequalMixin {
+  const AlfredItemMod({
+    this.arg,
+    this.subtitle,
+    this.icon,
+    this.valid = false,
+  });
+
+  /// The argument which is passed through the workflow to the connected output action.
+  @JsonKey(includeIfNull: false)
+  final String? arg;
+
+  /// The [subtitle] displayed in the result row. This element is optional.
+  @JsonKey(includeIfNull: false)
+  final String? subtitle;
+
+  /// The [icon] displayed in the result row.
+  @JsonKey(fromJson: _iconFromJson, includeIfNull: false)
+  final AlfredItemIcon? icon;
+
+  /// [valid] : true | false (optional, default = false)
+  final bool valid;
+
+  factory AlfredItemMod.fromJson(Map<String, dynamic> json) =>
+      _$AlfredItemModFromJson(json);
+
+  Map<String, dynamic> toJson() => _$AlfredItemModToJson(this);
+
+  static AlfredItemIcon? _iconFromJson(dynamic icon) => icon == null
+      ? null
+      : AlfredItemIcon.fromJson(Map<String, dynamic>.from(icon));
+}

--- a/lib/src/models/alfred_item_mod.dart
+++ b/lib/src/models/alfred_item_mod.dart
@@ -30,7 +30,7 @@ class AlfredItemMod with EquatableMixin, _$AlfredItemModAutoequalMixin {
     this.arg,
     this.subtitle,
     this.icon,
-    this.valid = false,
+    this.valid = true,
   });
 
   /// The argument which is passed through the workflow to the connected output action.

--- a/lib/src/models/alfred_item_mod.g.dart
+++ b/lib/src/models/alfred_item_mod.g.dart
@@ -1,0 +1,132 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'alfred_item_mod.dart';
+
+// **************************************************************************
+// AutoequalGenerator
+// **************************************************************************
+
+mixin _$AlfredItemModAutoequalMixin on EquatableMixin {
+  @override
+  List<Object?> get props =>
+      _$AlfredItemModAutoequal(this as AlfredItemMod)._$props;
+}
+
+extension _$AlfredItemModAutoequal on AlfredItemMod {
+  List<Object?> get _$props => [arg, subtitle, icon, valid];
+}
+
+// **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$AlfredItemModCWProxy {
+  AlfredItemMod arg(String? arg);
+
+  AlfredItemMod subtitle(String? subtitle);
+
+  AlfredItemMod icon(AlfredItemIcon? icon);
+
+  AlfredItemMod valid(bool valid);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `AlfredItemMod(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// AlfredItemMod(...).copyWith(id: 12, name: "My name")
+  /// ````
+  AlfredItemMod call({
+    String? arg,
+    String? subtitle,
+    AlfredItemIcon? icon,
+    bool? valid,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfAlfredItemMod.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfAlfredItemMod.copyWith.fieldName(...)`
+class _$AlfredItemModCWProxyImpl implements _$AlfredItemModCWProxy {
+  const _$AlfredItemModCWProxyImpl(this._value);
+
+  final AlfredItemMod _value;
+
+  @override
+  AlfredItemMod arg(String? arg) => this(arg: arg);
+
+  @override
+  AlfredItemMod subtitle(String? subtitle) => this(subtitle: subtitle);
+
+  @override
+  AlfredItemMod icon(AlfredItemIcon? icon) => this(icon: icon);
+
+  @override
+  AlfredItemMod valid(bool valid) => this(valid: valid);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `AlfredItemMod(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// AlfredItemMod(...).copyWith(id: 12, name: "My name")
+  /// ````
+  AlfredItemMod call({
+    Object? arg = const $CopyWithPlaceholder(),
+    Object? subtitle = const $CopyWithPlaceholder(),
+    Object? icon = const $CopyWithPlaceholder(),
+    Object? valid = const $CopyWithPlaceholder(),
+  }) {
+    return AlfredItemMod(
+      arg: arg == const $CopyWithPlaceholder()
+          ? _value.arg
+          // ignore: cast_nullable_to_non_nullable
+          : arg as String?,
+      subtitle: subtitle == const $CopyWithPlaceholder()
+          ? _value.subtitle
+          // ignore: cast_nullable_to_non_nullable
+          : subtitle as String?,
+      icon: icon == const $CopyWithPlaceholder()
+          ? _value.icon
+          // ignore: cast_nullable_to_non_nullable
+          : icon as AlfredItemIcon?,
+      valid: valid == const $CopyWithPlaceholder() || valid == null
+          // ignore: unnecessary_non_null_assertion
+          ? _value.valid!
+          // ignore: cast_nullable_to_non_nullable
+          : valid as bool,
+    );
+  }
+}
+
+extension $AlfredItemModCopyWith on AlfredItemMod {
+  /// Returns a callable class that can be used as follows: `instanceOfAlfredItemMod.copyWith(...)` or like so:`instanceOfAlfredItemMod.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$AlfredItemModCWProxy get copyWith => _$AlfredItemModCWProxyImpl(this);
+}
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+AlfredItemMod _$AlfredItemModFromJson(Map<String, dynamic> json) =>
+    AlfredItemMod(
+      arg: json['arg'] as String?,
+      subtitle: json['subtitle'] as String?,
+      icon: AlfredItemMod._iconFromJson(json['icon']),
+      valid: json['valid'] as bool? ?? false,
+    );
+
+Map<String, dynamic> _$AlfredItemModToJson(AlfredItemMod instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('arg', instance.arg);
+  writeNotNull('subtitle', instance.subtitle);
+  writeNotNull('icon', instance.icon?.toJson());
+  val['valid'] = instance.valid;
+  return val;
+}

--- a/lib/src/models/alfred_item_mod.g.dart
+++ b/lib/src/models/alfred_item_mod.g.dart
@@ -112,7 +112,7 @@ AlfredItemMod _$AlfredItemModFromJson(Map<String, dynamic> json) =>
       arg: json['arg'] as String?,
       subtitle: json['subtitle'] as String?,
       icon: AlfredItemMod._iconFromJson(json['icon']),
-      valid: json['valid'] as bool? ?? false,
+      valid: json['valid'] as bool? ?? true,
     );
 
 Map<String, dynamic> _$AlfredItemModToJson(AlfredItemMod instance) {

--- a/lib/src/models/index.dart
+++ b/lib/src/models/index.dart
@@ -1,6 +1,7 @@
 export 'alfred_item.dart' show AlfredItem;
 export 'alfred_item_icon.dart' show AlfredItemIcon, AlfredItemIconType;
 export 'alfred_item_text.dart' show AlfredItemText;
+export 'alfred_item_mod.dart' show AlfredItemMod, AlfredItemModKey;
 export 'alfred_items.dart' show AlfredItems;
 export 'github_asset.dart' show GithubAsset;
 export 'github_release.dart' show GithubRelease;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: alfred_workflow
 description: A helper library in Dart for authors of workflows for Alfred.
 homepage: https://github.com/techouse/alfred_workflow
 
-version: 0.2.11
+version: 0.2.12
 
 platforms:
   macos:

--- a/test/fixtures/models/alfred_item_fixture.dart
+++ b/test/fixtures/models/alfred_item_fixture.dart
@@ -1,9 +1,11 @@
 import 'package:alfred_workflow/alfred_workflow.dart';
 import 'package:alfred_workflow/src/models/alfred_item.dart';
+import 'package:alfred_workflow/src/models/alfred_item_mod.dart';
 import 'package:data_fixture_dart/data_fixture_dart.dart';
 import 'package:meta/meta.dart';
 
 import 'alfred_item_icon_fixture.dart';
+import 'alfred_item_mod_fixture.dart';
 import 'alfred_item_text_fixture.dart';
 
 extension AlfredItemFixture on AlfredItem {
@@ -31,6 +33,19 @@ class AlfredItemFactory extends FixtureFactory<AlfredItem> {
               : null,
           match:
               faker.randomGenerator.boolean() ? faker.lorem.sentence() : null,
+          mods: faker.randomGenerator.boolean()
+              ? {
+                  {AlfredItemModKey.cmd}:
+                      AlfredItemModFixture.factory.makeSingle(),
+                  {AlfredItemModKey.ctrl, AlfredItemModKey.alt}:
+                      AlfredItemModFixture.factory.makeSingle(),
+                  {
+                    AlfredItemModKey.cmd,
+                    AlfredItemModKey.shift,
+                    AlfredItemModKey.alt,
+                  }: AlfredItemModFixture.factory.makeSingle(),
+                }
+              : null,
         ),
       );
 
@@ -66,4 +81,9 @@ class AlfredItemFactory extends FixtureFactory<AlfredItem> {
 
   FixtureRedefinitionBuilder<AlfredItem> match(String? value) =>
       (AlfredItem item) => item.copyWith(match: value);
+
+  FixtureRedefinitionBuilder<AlfredItem> mods(
+    Map<Set<AlfredItemModKey>, AlfredItemMod>? value,
+  ) =>
+      (AlfredItem item) => item.copyWith(mods: value);
 }

--- a/test/fixtures/models/alfred_item_fixture.dart
+++ b/test/fixtures/models/alfred_item_fixture.dart
@@ -1,6 +1,5 @@
 import 'package:alfred_workflow/alfred_workflow.dart';
 import 'package:alfred_workflow/src/models/alfred_item.dart';
-import 'package:alfred_workflow/src/models/alfred_item_mod.dart';
 import 'package:data_fixture_dart/data_fixture_dart.dart';
 import 'package:meta/meta.dart';
 

--- a/test/fixtures/models/alfred_item_mod_fixture.dart
+++ b/test/fixtures/models/alfred_item_mod_fixture.dart
@@ -1,0 +1,38 @@
+import 'package:alfred_workflow/src/models/alfred_item_icon.dart';
+import 'package:alfred_workflow/src/models/alfred_item_mod.dart';
+import 'package:data_fixture_dart/data_fixture_dart.dart';
+import 'package:meta/meta.dart';
+
+import 'alfred_item_icon_fixture.dart';
+
+extension AlfredItemModFixture on AlfredItemMod {
+  static AlfredItemModFactory get factory => AlfredItemModFactory();
+}
+
+@internal
+class AlfredItemModFactory extends FixtureFactory<AlfredItemMod> {
+  @override
+  FixtureDefinition<AlfredItemMod> definition() => define(
+        (Faker faker) => AlfredItemMod(
+          arg: faker.randomGenerator.boolean() ? faker.lorem.sentence() : null,
+          subtitle:
+              faker.randomGenerator.boolean() ? faker.lorem.sentence() : null,
+          icon: faker.randomGenerator.boolean()
+              ? AlfredItemIconFixture.factory.makeSingle()
+              : null,
+          valid: faker.randomGenerator.boolean(),
+        ),
+      );
+
+  FixtureRedefinitionBuilder<AlfredItemMod> arg(String value) =>
+      (AlfredItemMod item) => item.copyWith(arg: value);
+
+  FixtureRedefinitionBuilder<AlfredItemMod> subtitle(String value) =>
+      (AlfredItemMod item) => item.copyWith(subtitle: value);
+
+  FixtureRedefinitionBuilder<AlfredItemMod> icon(AlfredItemIcon value) =>
+      (AlfredItemMod item) => item.copyWith(icon: value);
+
+  FixtureRedefinitionBuilder<AlfredItemMod> valid(bool value) =>
+      (AlfredItemMod item) => item.copyWith(valid: value);
+}


### PR DESCRIPTION
## mods : OBJECT (optional)

The mod element gives you control over how the modifier keys react. It can alter the looks of a result (e.g. subtitle, icon) and output a different arg or [session variables](https://www.alfredapp.com/help/workflows/inputs/script-filter/json/#variables).
```json
"mods": {
    "alt": {
        "valid": true,
        "arg": "alfredapp.com/powerpack/",
        "subtitle": "https://www.alfredapp.com/powerpack/"
    },
    "cmd": {
        "valid": true,
        "arg": "alfredapp.com/shop/",
        "subtitle": "https://www.alfredapp.com/shop/"
    },
    "cmd+alt": {
        "valid": true,
        "arg": "alfredapp.com/blog/",
        "subtitle": "https://www.alfredapp.com/blog/"
    },
}
```
Valid modifiers include **cmd** (⌘), **alt** (⌥), **ctrl** (⌃), **shift** (⇧), fn, and any combination through the use of +. For example: **cmd** + **alt** only activates when both keys are pressed.