### PR TITLE
:safety_vest: AlfredWorkflow.getItems is never nullable

### DIFF
--- a/lib/alfred_workflow.dart
+++ b/lib/alfred_workflow.dart
@@ -82,8 +82,12 @@ final class AlfredWorkflow {
   }
 
   /// Always use this to check for any AlfredItems.
-  Future<AlfredItems?> getItems() async =>
-      cacheKey != null ? await (await _cache).get(cacheKey!.md5hex) : _items;
+  Future<AlfredItems> getItems() async {
+    return switch (cacheKey) {
+      null => _items,
+      _ => await (await _cache).get(cacheKey!.md5hex) ?? _items,
+    };
+  }
 
   /// Add multiple [items]
   ///
@@ -145,7 +149,7 @@ final class AlfredWorkflow {
     AlfredItem? addToEnd,
   }) async {
     final AlfredItems items = AlfredItems(
-      [...(await getItems() ?? _items).items],
+      [...(await getItems()).items],
       exactOrder: disableAlfredSmartResultOrdering,
       skipKnowledge: skipKnowledge,
       cache: automaticCache,

--- a/test/unit/alfred_workflow_test.dart
+++ b/test/unit/alfred_workflow_test.dart
@@ -45,11 +45,11 @@ void main() async {
       'addItem with toBeginning=false adds single item to end of items',
       () async {
         await workflow.addItems(AlfredItemFixture.factory.makeMany(10));
-        expect((await workflow.getItems())?.items.length, 10);
+        expect((await workflow.getItems()).items.length, 10);
 
         await workflow.addItem(item);
-        expect((await workflow.getItems())?.items.length, 11);
-        expect((await workflow.getItems())?.items.last, item);
+        expect((await workflow.getItems()).items.length, 11);
+        expect((await workflow.getItems()).items.last, item);
       },
     );
 
@@ -57,12 +57,12 @@ void main() async {
       'addItem with toBeginning=true adds single item to beginning of items',
       () async {
         await workflow.addItems(AlfredItemFixture.factory.makeMany(10));
-        expect((await workflow.getItems())?.items.length, 10);
+        expect((await workflow.getItems()).items.length, 10);
 
         await workflow.addItem(item, toBeginning: true);
-        expect((await workflow.getItems())?.items.length, 11);
-        expect((await workflow.getItems())?.items.first, item);
-        expect((await workflow.getItems())?.items.last == item, false);
+        expect((await workflow.getItems()).items.length, 11);
+        expect((await workflow.getItems()).items.first, item);
+        expect((await workflow.getItems()).items.last == item, false);
       },
     );
 
@@ -132,11 +132,11 @@ void main() async {
       'addItem with toBeginning=false adds single item to end of items',
       () async {
         await workflow.addItems(AlfredItemFixture.factory.makeMany(10));
-        expect((await workflow.getItems())?.items.length, 10);
+        expect((await workflow.getItems()).items.length, 10);
 
         await workflow.addItem(item);
-        expect((await workflow.getItems())?.items.length, 11);
-        expect((await workflow.getItems())?.items.last, item);
+        expect((await workflow.getItems()).items.length, 11);
+        expect((await workflow.getItems()).items.last, item);
       },
     );
 
@@ -144,12 +144,12 @@ void main() async {
       'addItem with toBeginning=true adds single item to beginning of items',
       () async {
         await workflow.addItems(AlfredItemFixture.factory.makeMany(10));
-        expect((await workflow.getItems())?.items.length, 10);
+        expect((await workflow.getItems()).items.length, 10);
 
         await workflow.addItem(item, toBeginning: true);
-        expect((await workflow.getItems())?.items.length, 11);
-        expect((await workflow.getItems())?.items.first, item);
-        expect((await workflow.getItems())?.items.last == item, false);
+        expect((await workflow.getItems()).items.length, 11);
+        expect((await workflow.getItems()).items.first, item);
+        expect((await workflow.getItems()).items.last == item, false);
       },
     );
 
@@ -189,8 +189,8 @@ void main() async {
         ..cacheKey = faker.guid.guid();
     });
 
-    test('getItems without adding anything is null', () async {
-      expect(await workflow.getItems(), null);
+    test('getItems without adding anything is empty', () async {
+      expect(await workflow.getItems(), const AlfredItems([]));
     });
 
     test('addItem adds single item', () async {
@@ -207,11 +207,11 @@ void main() async {
       'addItem with toBeginning=false adds single item to end of items',
       () async {
         await workflow.addItems(AlfredItemFixture.factory.makeMany(10));
-        expect((await workflow.getItems())?.items.length, 10);
+        expect((await workflow.getItems()).items.length, 10);
 
         await workflow.addItem(item);
-        expect((await workflow.getItems())?.items.length, 11);
-        expect((await workflow.getItems())?.items.last, item);
+        expect((await workflow.getItems()).items.length, 11);
+        expect((await workflow.getItems()).items.last, item);
       },
     );
 
@@ -219,12 +219,12 @@ void main() async {
       'addItem with toBeginning=true adds single item to beginning of items',
       () async {
         await workflow.addItems(AlfredItemFixture.factory.makeMany(10));
-        expect((await workflow.getItems())?.items.length, 10);
+        expect((await workflow.getItems()).items.length, 10);
 
         await workflow.addItem(item, toBeginning: true);
-        expect((await workflow.getItems())?.items.length, 11);
-        expect((await workflow.getItems())?.items.first, item);
-        expect((await workflow.getItems())?.items.last == item, false);
+        expect((await workflow.getItems()).items.length, 11);
+        expect((await workflow.getItems()).items.first, item);
+        expect((await workflow.getItems()).items.last == item, false);
       },
     );
 
@@ -233,7 +233,7 @@ void main() async {
       expect(await workflow.getItems(), AlfredItems(itemsList));
 
       await workflow.clearItems();
-      expect(await workflow.getItems(), null);
+      expect(await workflow.getItems(), const AlfredItems([]));
     });
 
     test('toJsonString returns a JSON string', () async {
@@ -286,11 +286,11 @@ void main() async {
       'addItem with toBeginning=false adds single item to end of items',
       () async {
         await workflow.addItems(AlfredItemFixture.factory.makeMany(10));
-        expect((await workflow.getItems())?.items.length, 10);
+        expect((await workflow.getItems()).items.length, 10);
 
         await workflow.addItem(item);
-        expect((await workflow.getItems())?.items.length, 11);
-        expect((await workflow.getItems())?.items.last, item);
+        expect((await workflow.getItems()).items.length, 11);
+        expect((await workflow.getItems()).items.last, item);
       },
     );
 
@@ -298,12 +298,12 @@ void main() async {
       'addItem with toBeginning=true adds single item to beginning of items',
       () async {
         await workflow.addItems(AlfredItemFixture.factory.makeMany(10));
-        expect((await workflow.getItems())?.items.length, 10);
+        expect((await workflow.getItems()).items.length, 10);
 
         await workflow.addItem(item, toBeginning: true);
-        expect((await workflow.getItems())?.items.length, 11);
-        expect((await workflow.getItems())?.items.first, item);
-        expect((await workflow.getItems())?.items.last == item, false);
+        expect((await workflow.getItems()).items.length, 11);
+        expect((await workflow.getItems()).items.first, item);
+        expect((await workflow.getItems()).items.last == item, false);
       },
     );
 


### PR DESCRIPTION
This pull request includes changes to the `lib/alfred_workflow.dart` and `test/unit/alfred_workflow_test.dart` files to improve the handling of `AlfredItems` and enhance the test coverage. The most important changes include modifying the `getItems` method, updating the `addItems` method, and refining the test cases to ensure consistency and correctness.

Improvements to `getItems` method:

* [`lib/alfred_workflow.dart`](diffhunk://#diff-741ec5603a8b91be5b706d2cc07e60a4a341e8d37bc9c354e3cff66ee4fe4213L85-R90): Modified the `getItems` method to use a switch statement for better readability and to ensure it always returns `AlfredItems`.

Enhancements to `addItems` method:

* [`lib/alfred_workflow.dart`](diffhunk://#diff-741ec5603a8b91be5b706d2cc07e60a4a341e8d37bc9c354e3cff66ee4fe4213L148-R152): Updated the `addItems` method to remove the unnecessary null check on `getItems`.

Refinements to test cases:

* [`test/unit/alfred_workflow_test.dart`](diffhunk://#diff-fa5c0af771421232f01fd16b83365244e5bb79e17fea0157e7cd2274f02f0f16L48-R65): Updated multiple test cases to remove optional chaining, ensuring `getItems` always returns `AlfredItems`. [[1]](diffhunk://#diff-fa5c0af771421232f01fd16b83365244e5bb79e17fea0157e7cd2274f02f0f16L48-R65) [[2]](diffhunk://#diff-fa5c0af771421232f01fd16b83365244e5bb79e17fea0157e7cd2274f02f0f16L135-R152) [[3]](diffhunk://#diff-fa5c0af771421232f01fd16b83365244e5bb79e17fea0157e7cd2274f02f0f16L210-R227) [[4]](diffhunk://#diff-fa5c0af771421232f01fd16b83365244e5bb79e17fea0157e7cd2274f02f0f16L289-R306)
* [`test/unit/alfred_workflow_test.dart`](diffhunk://#diff-fa5c0af771421232f01fd16b83365244e5bb79e17fea0157e7cd2274f02f0f16L192-R193): Modified test cases to expect an empty `AlfredItems` object instead of null when no items are added. [[1]](diffhunk://#diff-fa5c0af771421232f01fd16b83365244e5bb79e17fea0157e7cd2274f02f0f16L192-R193) [[2]](diffhunk://#diff-fa5c0af771421232f01fd16b83365244e5bb79e17fea0157e7cd2274f02f0f16L236-R236)