### PR TITLE
:sparkles: add number slider configuration support in user settings

### DIFF
--- a/lib/src/extensions/user_defaults.dart
+++ b/lib/src/extensions/user_defaults.dart
@@ -116,6 +116,9 @@ extension UserDefaults on AlfredWorkflow {
             else if (config[_typeKey] ==
                 AlfredUserConfigurationType.filePicker.jsonValue)
               AlfredUserConfigurationFilePicker.fromJson(config)
+            else if (config[_typeKey] ==
+                AlfredUserConfigurationType.slider.jsonValue)
+              AlfredUserConfigurationNumberSlider.fromJson(config)
         ])
           item.variable: item,
       };

--- a/lib/src/models/alfred_user_configuration.dart
+++ b/lib/src/models/alfred_user_configuration.dart
@@ -8,8 +8,8 @@ part 'alfred_user_configuration.g.dart';
 
 /// Alfred user configuration generic class
 @autoequal
-abstract class AlfredUserConfiguration<T extends AlfredUserConfigurationConfig>
-    with EquatableMixin {
+abstract class AlfredUserConfiguration<T,
+    Q extends AlfredUserConfigurationConfig<T>> with EquatableMixin {
   const AlfredUserConfiguration({
     required this.type,
     required this.variable,
@@ -30,10 +30,16 @@ abstract class AlfredUserConfiguration<T extends AlfredUserConfigurationConfig>
   final String? label;
 
   /// [AlfredUserConfigurationConfig] configuration
-  abstract final T config;
+  abstract final Q config;
+
+  /// Default value
+  T get defaultValue => config.defaultValue;
+
+  /// User set value
+  T get value => config.value;
 
   @internal
-  AlfredUserConfiguration<T> copyWithConfig(T config);
+  AlfredUserConfiguration<T, Q> copyWithConfig(Q config);
 
   @override
   List<Object?> get props => _$props;

--- a/lib/src/models/alfred_user_configuration_check_box.dart
+++ b/lib/src/models/alfred_user_configuration_check_box.dart
@@ -14,7 +14,7 @@ part 'alfred_user_configuration_check_box.g.dart';
 @CopyWith()
 @JsonSerializable(explicitToJson: true, createToJson: false)
 final class AlfredUserConfigurationCheckBox
-    extends AlfredUserConfiguration<AlfredUserConfigurationConfigCheckBox>
+    extends AlfredUserConfiguration<bool, AlfredUserConfigurationConfigCheckBox>
     with EquatableMixin {
   const AlfredUserConfigurationCheckBox({
     required super.type,
@@ -31,9 +31,9 @@ final class AlfredUserConfigurationCheckBox
 
   @internal
   @override
-  AlfredUserConfiguration<AlfredUserConfigurationConfigCheckBox> copyWithConfig(
-          AlfredUserConfigurationConfigCheckBox config) =>
-      copyWith(config: config);
+  AlfredUserConfiguration<bool, AlfredUserConfigurationConfigCheckBox>
+      copyWithConfig(AlfredUserConfigurationConfigCheckBox config) =>
+          copyWith(config: config);
 
   static AlfredUserConfigurationConfigCheckBox _configFromJson(Map json) =>
       AlfredUserConfigurationConfigCheckBox.fromJson(

--- a/lib/src/models/alfred_user_configuration_check_box.g.dart
+++ b/lib/src/models/alfred_user_configuration_check_box.g.dart
@@ -129,4 +129,5 @@ const _$AlfredUserConfigurationTypeEnumMap = {
   AlfredUserConfigurationType.checkBox: 'checkbox',
   AlfredUserConfigurationType.select: 'popupbutton',
   AlfredUserConfigurationType.filePicker: 'filepicker',
+  AlfredUserConfigurationType.slider: 'slider',
 };

--- a/lib/src/models/alfred_user_configuration_config.dart
+++ b/lib/src/models/alfred_user_configuration_config.dart
@@ -14,14 +14,17 @@ abstract class AlfredUserConfigurationConfig<T> with EquatableMixin {
   }) : value = value ?? defaultValue;
 
   /// Default value
-  @JsonKey(name: 'default')
+  @JsonKey(name: 'default', readValue: fromJsonDefaultValue)
   final T defaultValue;
+
+  @internal
+  static T fromJsonDefaultValue<T>(Map json, String key) =>
+      json['defaultvalue'] as T? ?? json[key] as T;
 
   /// User set value
   @JsonKey(includeFromJson: false, includeToJson: false)
   final T value;
 
-  @internal
   @internal
   AlfredUserConfigurationConfig<T> copyWithValue(T? value);
 

--- a/lib/src/models/alfred_user_configuration_config_check_box.g.dart
+++ b/lib/src/models/alfred_user_configuration_config_check_box.g.dart
@@ -102,7 +102,8 @@ AlfredUserConfigurationConfigCheckBox
     _$AlfredUserConfigurationConfigCheckBoxFromJson(
             Map<String, dynamic> json) =>
         AlfredUserConfigurationConfigCheckBox(
-          defaultValue: json['default'] as bool,
+          defaultValue: AlfredUserConfigurationConfig.fromJsonDefaultValue(
+              json, 'default') as bool,
           required: json['required'] as bool,
           text: json['text'] as String?,
         );

--- a/lib/src/models/alfred_user_configuration_config_file_picker.g.dart
+++ b/lib/src/models/alfred_user_configuration_config_file_picker.g.dart
@@ -115,7 +115,8 @@ AlfredUserConfigurationConfigFilePicker
     _$AlfredUserConfigurationConfigFilePickerFromJson(
             Map<String, dynamic> json) =>
         AlfredUserConfigurationConfigFilePicker(
-          defaultValue: json['default'] as String,
+          defaultValue: AlfredUserConfigurationConfig.fromJsonDefaultValue(
+              json, 'default') as String,
           required: json['required'] as bool,
           filterMode: (json['filtermode'] as num).toInt(),
           placeholder: json['placeholder'] as String?,

--- a/lib/src/models/alfred_user_configuration_config_number_slider.dart
+++ b/lib/src/models/alfred_user_configuration_config_number_slider.dart
@@ -1,0 +1,74 @@
+import 'package:alfred_workflow/src/models/alfred_user_configuration_config.dart';
+import 'package:autoequal/autoequal.dart';
+import 'package:copy_with_extension/copy_with_extension.dart';
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:meta/meta.dart';
+
+part 'alfred_user_configuration_config_number_slider.g.dart';
+
+/// Alfred integer slider user configuration config
+@autoequal
+@CopyWith()
+@JsonSerializable(explicitToJson: true, createToJson: false)
+final class AlfredUserConfigurationConfigNumberSlider
+    extends AlfredUserConfigurationConfig<int> with EquatableMixin {
+  const AlfredUserConfigurationConfigNumberSlider({
+    required super.defaultValue,
+    super.value,
+    required this.min,
+    required this.max,
+    this.onlyStopOnMarkers = false,
+    this.showMarkers = false,
+    this.markerCount,
+  })  : assert(min < max, 'min must be less than max'),
+        assert(
+          defaultValue >= min && defaultValue <= max,
+          'defaultValue must be between min and max',
+        ),
+        assert(
+          value == null || (value >= min && value <= max),
+          'value must be between min and max',
+        ),
+        assert(
+          showMarkers == false || markerCount != null,
+          'markerCount must be provided if showMarkers is true',
+        ),
+        assert(
+          showMarkers == false || markerCount != 0,
+          'markerCount must be greater than 0 if showMarkers is true',
+        ),
+        assert(
+          onlyStopOnMarkers == false || markerCount != null,
+          'markerCount must be provided if onlyStopOnMarkers is true',
+        ),
+        assert(
+          onlyStopOnMarkers == false || markerCount != 0,
+          'markerCount must be greater than 0 if onlyStopOnMarkers is true',
+        ),
+        assert(
+          markerCount == null || markerCount > 0,
+          'markerCount must be greater than 0 if provided',
+        );
+
+  @JsonKey(name: 'minvalue')
+  final int min;
+  @JsonKey(name: 'maxvalue')
+  final int max;
+  @JsonKey(name: 'showmarkers')
+  final bool showMarkers;
+  @JsonKey(name: 'onlystoponmarkers')
+  final bool onlyStopOnMarkers;
+  @JsonKey(name: 'markercount')
+  final int? markerCount;
+
+  @internal
+  @override
+  AlfredUserConfigurationConfig<int> copyWithValue(int? value) =>
+      copyWith(value: value);
+
+  factory AlfredUserConfigurationConfigNumberSlider.fromJson(Map json) =>
+      _$AlfredUserConfigurationConfigNumberSliderFromJson(
+        json.map((k, v) => MapEntry(k.toString(), v)),
+      );
+}

--- a/lib/src/models/alfred_user_configuration_config_number_slider.dart
+++ b/lib/src/models/alfred_user_configuration_config_number_slider.dart
@@ -31,20 +31,12 @@ final class AlfredUserConfigurationConfigNumberSlider
           'value must be between min and max',
         ),
         assert(
-          showMarkers == false || markerCount != null,
-          'markerCount must be provided if showMarkers is true',
+          !(showMarkers || onlyStopOnMarkers) || markerCount != null,
+          'markerCount must be provided if showMarkers or onlyStopOnMarkers is true',
         ),
         assert(
-          showMarkers == false || markerCount != 0,
-          'markerCount must be greater than 0 if showMarkers is true',
-        ),
-        assert(
-          onlyStopOnMarkers == false || markerCount != null,
-          'markerCount must be provided if onlyStopOnMarkers is true',
-        ),
-        assert(
-          onlyStopOnMarkers == false || markerCount != 0,
-          'markerCount must be greater than 0 if onlyStopOnMarkers is true',
+          !(showMarkers || onlyStopOnMarkers) || markerCount != 0,
+          'markerCount must be greater than 0 if showMarkers or onlyStopOnMarkers is true',
         ),
         assert(
           markerCount == null || markerCount > 0,

--- a/lib/src/models/alfred_user_configuration_config_number_slider.g.dart
+++ b/lib/src/models/alfred_user_configuration_config_number_slider.g.dart
@@ -1,0 +1,150 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'alfred_user_configuration_config_number_slider.dart';
+
+// **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$AlfredUserConfigurationConfigNumberSliderCWProxy {
+  AlfredUserConfigurationConfigNumberSlider defaultValue(int defaultValue);
+
+  AlfredUserConfigurationConfigNumberSlider value(int? value);
+
+  AlfredUserConfigurationConfigNumberSlider min(int min);
+
+  AlfredUserConfigurationConfigNumberSlider max(int max);
+
+  AlfredUserConfigurationConfigNumberSlider onlyStopOnMarkers(
+      bool onlyStopOnMarkers);
+
+  AlfredUserConfigurationConfigNumberSlider showMarkers(bool showMarkers);
+
+  AlfredUserConfigurationConfigNumberSlider markerCount(int? markerCount);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `AlfredUserConfigurationConfigNumberSlider(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// AlfredUserConfigurationConfigNumberSlider(...).copyWith(id: 12, name: "My name")
+  /// ````
+  AlfredUserConfigurationConfigNumberSlider call({
+    int defaultValue,
+    int? value,
+    int min,
+    int max,
+    bool onlyStopOnMarkers,
+    bool showMarkers,
+    int? markerCount,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfAlfredUserConfigurationConfigNumberSlider.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfAlfredUserConfigurationConfigNumberSlider.copyWith.fieldName(...)`
+class _$AlfredUserConfigurationConfigNumberSliderCWProxyImpl
+    implements _$AlfredUserConfigurationConfigNumberSliderCWProxy {
+  const _$AlfredUserConfigurationConfigNumberSliderCWProxyImpl(this._value);
+
+  final AlfredUserConfigurationConfigNumberSlider _value;
+
+  @override
+  AlfredUserConfigurationConfigNumberSlider defaultValue(int defaultValue) =>
+      this(defaultValue: defaultValue);
+
+  @override
+  AlfredUserConfigurationConfigNumberSlider value(int? value) =>
+      this(value: value);
+
+  @override
+  AlfredUserConfigurationConfigNumberSlider min(int min) => this(min: min);
+
+  @override
+  AlfredUserConfigurationConfigNumberSlider max(int max) => this(max: max);
+
+  @override
+  AlfredUserConfigurationConfigNumberSlider onlyStopOnMarkers(
+          bool onlyStopOnMarkers) =>
+      this(onlyStopOnMarkers: onlyStopOnMarkers);
+
+  @override
+  AlfredUserConfigurationConfigNumberSlider showMarkers(bool showMarkers) =>
+      this(showMarkers: showMarkers);
+
+  @override
+  AlfredUserConfigurationConfigNumberSlider markerCount(int? markerCount) =>
+      this(markerCount: markerCount);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `AlfredUserConfigurationConfigNumberSlider(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// AlfredUserConfigurationConfigNumberSlider(...).copyWith(id: 12, name: "My name")
+  /// ````
+  AlfredUserConfigurationConfigNumberSlider call({
+    Object? defaultValue = const $CopyWithPlaceholder(),
+    Object? value = const $CopyWithPlaceholder(),
+    Object? min = const $CopyWithPlaceholder(),
+    Object? max = const $CopyWithPlaceholder(),
+    Object? onlyStopOnMarkers = const $CopyWithPlaceholder(),
+    Object? showMarkers = const $CopyWithPlaceholder(),
+    Object? markerCount = const $CopyWithPlaceholder(),
+  }) {
+    return AlfredUserConfigurationConfigNumberSlider(
+      defaultValue: defaultValue == const $CopyWithPlaceholder()
+          ? _value.defaultValue
+          // ignore: cast_nullable_to_non_nullable
+          : defaultValue as int,
+      value: value == const $CopyWithPlaceholder()
+          ? _value.value
+          // ignore: cast_nullable_to_non_nullable
+          : value as int?,
+      min: min == const $CopyWithPlaceholder()
+          ? _value.min
+          // ignore: cast_nullable_to_non_nullable
+          : min as int,
+      max: max == const $CopyWithPlaceholder()
+          ? _value.max
+          // ignore: cast_nullable_to_non_nullable
+          : max as int,
+      onlyStopOnMarkers: onlyStopOnMarkers == const $CopyWithPlaceholder()
+          ? _value.onlyStopOnMarkers
+          // ignore: cast_nullable_to_non_nullable
+          : onlyStopOnMarkers as bool,
+      showMarkers: showMarkers == const $CopyWithPlaceholder()
+          ? _value.showMarkers
+          // ignore: cast_nullable_to_non_nullable
+          : showMarkers as bool,
+      markerCount: markerCount == const $CopyWithPlaceholder()
+          ? _value.markerCount
+          // ignore: cast_nullable_to_non_nullable
+          : markerCount as int?,
+    );
+  }
+}
+
+extension $AlfredUserConfigurationConfigNumberSliderCopyWith
+    on AlfredUserConfigurationConfigNumberSlider {
+  /// Returns a callable class that can be used as follows: `instanceOfAlfredUserConfigurationConfigNumberSlider.copyWith(...)` or like so:`instanceOfAlfredUserConfigurationConfigNumberSlider.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$AlfredUserConfigurationConfigNumberSliderCWProxy get copyWith =>
+      _$AlfredUserConfigurationConfigNumberSliderCWProxyImpl(this);
+}
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+AlfredUserConfigurationConfigNumberSlider
+    _$AlfredUserConfigurationConfigNumberSliderFromJson(
+            Map<String, dynamic> json) =>
+        AlfredUserConfigurationConfigNumberSlider(
+          defaultValue: (AlfredUserConfigurationConfig.fromJsonDefaultValue(
+                  json, 'default') as num)
+              .toInt(),
+          min: (json['minvalue'] as num).toInt(),
+          max: (json['maxvalue'] as num).toInt(),
+          onlyStopOnMarkers: json['onlystoponmarkers'] as bool? ?? false,
+          showMarkers: json['showmarkers'] as bool? ?? false,
+          markerCount: (json['markercount'] as num?)?.toInt(),
+        );

--- a/lib/src/models/alfred_user_configuration_config_select.g.dart
+++ b/lib/src/models/alfred_user_configuration_config_select.g.dart
@@ -92,7 +92,8 @@ extension $AlfredUserConfigurationConfigSelectCopyWith
 AlfredUserConfigurationConfigSelect
     _$AlfredUserConfigurationConfigSelectFromJson(Map<String, dynamic> json) =>
         AlfredUserConfigurationConfigSelect(
-          defaultValue: json['default'] as String,
+          defaultValue: AlfredUserConfigurationConfig.fromJsonDefaultValue(
+              json, 'default') as String,
           pairs: AlfredUserConfigurationConfigSelect._pairsFromJson(
               json['pairs'] as List),
         );

--- a/lib/src/models/alfred_user_configuration_config_text_area.g.dart
+++ b/lib/src/models/alfred_user_configuration_config_text_area.g.dart
@@ -114,7 +114,8 @@ AlfredUserConfigurationConfigTextArea
     _$AlfredUserConfigurationConfigTextAreaFromJson(
             Map<String, dynamic> json) =>
         AlfredUserConfigurationConfigTextArea(
-          defaultValue: json['default'] as String,
+          defaultValue: AlfredUserConfigurationConfig.fromJsonDefaultValue(
+              json, 'default') as String,
           required: json['required'] as bool,
           trim: json['trim'] as bool,
           verticalSize: (json['verticalsize'] as num).toInt(),

--- a/lib/src/models/alfred_user_configuration_config_text_field.g.dart
+++ b/lib/src/models/alfred_user_configuration_config_text_field.g.dart
@@ -114,7 +114,8 @@ AlfredUserConfigurationConfigTextField
     _$AlfredUserConfigurationConfigTextFieldFromJson(
             Map<String, dynamic> json) =>
         AlfredUserConfigurationConfigTextField(
-          defaultValue: json['default'] as String,
+          defaultValue: AlfredUserConfigurationConfig.fromJsonDefaultValue(
+              json, 'default') as String,
           required: json['required'] as bool,
           trim: json['trim'] as bool,
           placeholder: json['placeholder'] as String?,

--- a/lib/src/models/alfred_user_configuration_file_picker.dart
+++ b/lib/src/models/alfred_user_configuration_file_picker.dart
@@ -13,9 +13,8 @@ part 'alfred_user_configuration_file_picker.g.dart';
 @autoequal
 @CopyWith()
 @JsonSerializable(explicitToJson: true, createToJson: false)
-final class AlfredUserConfigurationFilePicker
-    extends AlfredUserConfiguration<AlfredUserConfigurationConfigFilePicker>
-    with EquatableMixin {
+final class AlfredUserConfigurationFilePicker extends AlfredUserConfiguration<
+    String, AlfredUserConfigurationConfigFilePicker> with EquatableMixin {
   const AlfredUserConfigurationFilePicker({
     required super.type,
     required super.variable,
@@ -31,7 +30,7 @@ final class AlfredUserConfigurationFilePicker
 
   @internal
   @override
-  AlfredUserConfiguration<AlfredUserConfigurationConfigFilePicker>
+  AlfredUserConfiguration<String, AlfredUserConfigurationConfigFilePicker>
       copyWithConfig(AlfredUserConfigurationConfigFilePicker config) =>
           copyWith(config: config);
 

--- a/lib/src/models/alfred_user_configuration_file_picker.g.dart
+++ b/lib/src/models/alfred_user_configuration_file_picker.g.dart
@@ -129,4 +129,5 @@ const _$AlfredUserConfigurationTypeEnumMap = {
   AlfredUserConfigurationType.checkBox: 'checkbox',
   AlfredUserConfigurationType.select: 'popupbutton',
   AlfredUserConfigurationType.filePicker: 'filepicker',
+  AlfredUserConfigurationType.slider: 'slider',
 };

--- a/lib/src/models/alfred_user_configuration_number_slider.dart
+++ b/lib/src/models/alfred_user_configuration_number_slider.dart
@@ -13,9 +13,8 @@ part 'alfred_user_configuration_number_slider.g.dart';
 @autoequal
 @CopyWith()
 @JsonSerializable(explicitToJson: true, createToJson: false)
-final class AlfredUserConfigurationNumberSlider
-    extends AlfredUserConfiguration<AlfredUserConfigurationConfigNumberSlider>
-    with EquatableMixin {
+final class AlfredUserConfigurationNumberSlider extends AlfredUserConfiguration<
+    int, AlfredUserConfigurationConfigNumberSlider> with EquatableMixin {
   const AlfredUserConfigurationNumberSlider({
     required super.type,
     required super.variable,
@@ -31,7 +30,7 @@ final class AlfredUserConfigurationNumberSlider
 
   @internal
   @override
-  AlfredUserConfiguration<AlfredUserConfigurationConfigNumberSlider>
+  AlfredUserConfiguration<int, AlfredUserConfigurationConfigNumberSlider>
       copyWithConfig(AlfredUserConfigurationConfigNumberSlider config) =>
           copyWith(config: config);
 

--- a/lib/src/models/alfred_user_configuration_number_slider.dart
+++ b/lib/src/models/alfred_user_configuration_number_slider.dart
@@ -1,0 +1,47 @@
+import 'package:alfred_workflow/src/models/alfred_user_configuration.dart';
+import 'package:alfred_workflow/src/models/alfred_user_configuration_config_number_slider.dart';
+import 'package:alfred_workflow/src/models/alfred_user_configuration_type.dart';
+import 'package:autoequal/autoequal.dart';
+import 'package:copy_with_extension/copy_with_extension.dart';
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:meta/meta.dart';
+
+part 'alfred_user_configuration_number_slider.g.dart';
+
+/// Alfred text area user configuration
+@autoequal
+@CopyWith()
+@JsonSerializable(explicitToJson: true, createToJson: false)
+final class AlfredUserConfigurationNumberSlider
+    extends AlfredUserConfiguration<AlfredUserConfigurationConfigNumberSlider>
+    with EquatableMixin {
+  const AlfredUserConfigurationNumberSlider({
+    required super.type,
+    required super.variable,
+    required this.config,
+    super.description,
+    super.label,
+  });
+
+  /// The configuration for the text area
+  @override
+  @JsonKey(fromJson: _configFromJson)
+  final AlfredUserConfigurationConfigNumberSlider config;
+
+  @internal
+  @override
+  AlfredUserConfiguration<AlfredUserConfigurationConfigNumberSlider>
+      copyWithConfig(AlfredUserConfigurationConfigNumberSlider config) =>
+          copyWith(config: config);
+
+  static AlfredUserConfigurationConfigNumberSlider _configFromJson(Map json) =>
+      AlfredUserConfigurationConfigNumberSlider.fromJson(
+        json.map((k, v) => MapEntry(k.toString(), v)),
+      );
+
+  factory AlfredUserConfigurationNumberSlider.fromJson(Map json) =>
+      _$AlfredUserConfigurationNumberSliderFromJson(
+        json.map((k, v) => MapEntry(k.toString(), v)),
+      );
+}

--- a/lib/src/models/alfred_user_configuration_number_slider.dart
+++ b/lib/src/models/alfred_user_configuration_number_slider.dart
@@ -9,7 +9,7 @@ import 'package:meta/meta.dart';
 
 part 'alfred_user_configuration_number_slider.g.dart';
 
-/// Alfred text area user configuration
+/// Alfred number slider user configuration
 @autoequal
 @CopyWith()
 @JsonSerializable(explicitToJson: true, createToJson: false)
@@ -24,7 +24,7 @@ final class AlfredUserConfigurationNumberSlider
     super.label,
   });
 
-  /// The configuration for the text area
+  /// The configuration for the number slider
   @override
   @JsonKey(fromJson: _configFromJson)
   final AlfredUserConfigurationConfigNumberSlider config;

--- a/lib/src/models/alfred_user_configuration_number_slider.g.dart
+++ b/lib/src/models/alfred_user_configuration_number_slider.g.dart
@@ -1,0 +1,134 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'alfred_user_configuration_number_slider.dart';
+
+// **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$AlfredUserConfigurationNumberSliderCWProxy {
+  AlfredUserConfigurationNumberSlider type(AlfredUserConfigurationType type);
+
+  AlfredUserConfigurationNumberSlider variable(String variable);
+
+  AlfredUserConfigurationNumberSlider config(
+      AlfredUserConfigurationConfigNumberSlider config);
+
+  AlfredUserConfigurationNumberSlider description(String? description);
+
+  AlfredUserConfigurationNumberSlider label(String? label);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `AlfredUserConfigurationNumberSlider(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// AlfredUserConfigurationNumberSlider(...).copyWith(id: 12, name: "My name")
+  /// ````
+  AlfredUserConfigurationNumberSlider call({
+    AlfredUserConfigurationType type,
+    String variable,
+    AlfredUserConfigurationConfigNumberSlider config,
+    String? description,
+    String? label,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfAlfredUserConfigurationNumberSlider.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfAlfredUserConfigurationNumberSlider.copyWith.fieldName(...)`
+class _$AlfredUserConfigurationNumberSliderCWProxyImpl
+    implements _$AlfredUserConfigurationNumberSliderCWProxy {
+  const _$AlfredUserConfigurationNumberSliderCWProxyImpl(this._value);
+
+  final AlfredUserConfigurationNumberSlider _value;
+
+  @override
+  AlfredUserConfigurationNumberSlider type(AlfredUserConfigurationType type) =>
+      this(type: type);
+
+  @override
+  AlfredUserConfigurationNumberSlider variable(String variable) =>
+      this(variable: variable);
+
+  @override
+  AlfredUserConfigurationNumberSlider config(
+          AlfredUserConfigurationConfigNumberSlider config) =>
+      this(config: config);
+
+  @override
+  AlfredUserConfigurationNumberSlider description(String? description) =>
+      this(description: description);
+
+  @override
+  AlfredUserConfigurationNumberSlider label(String? label) =>
+      this(label: label);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `AlfredUserConfigurationNumberSlider(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// AlfredUserConfigurationNumberSlider(...).copyWith(id: 12, name: "My name")
+  /// ````
+  AlfredUserConfigurationNumberSlider call({
+    Object? type = const $CopyWithPlaceholder(),
+    Object? variable = const $CopyWithPlaceholder(),
+    Object? config = const $CopyWithPlaceholder(),
+    Object? description = const $CopyWithPlaceholder(),
+    Object? label = const $CopyWithPlaceholder(),
+  }) {
+    return AlfredUserConfigurationNumberSlider(
+      type: type == const $CopyWithPlaceholder()
+          ? _value.type
+          // ignore: cast_nullable_to_non_nullable
+          : type as AlfredUserConfigurationType,
+      variable: variable == const $CopyWithPlaceholder()
+          ? _value.variable
+          // ignore: cast_nullable_to_non_nullable
+          : variable as String,
+      config: config == const $CopyWithPlaceholder()
+          ? _value.config
+          // ignore: cast_nullable_to_non_nullable
+          : config as AlfredUserConfigurationConfigNumberSlider,
+      description: description == const $CopyWithPlaceholder()
+          ? _value.description
+          // ignore: cast_nullable_to_non_nullable
+          : description as String?,
+      label: label == const $CopyWithPlaceholder()
+          ? _value.label
+          // ignore: cast_nullable_to_non_nullable
+          : label as String?,
+    );
+  }
+}
+
+extension $AlfredUserConfigurationNumberSliderCopyWith
+    on AlfredUserConfigurationNumberSlider {
+  /// Returns a callable class that can be used as follows: `instanceOfAlfredUserConfigurationNumberSlider.copyWith(...)` or like so:`instanceOfAlfredUserConfigurationNumberSlider.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$AlfredUserConfigurationNumberSliderCWProxy get copyWith =>
+      _$AlfredUserConfigurationNumberSliderCWProxyImpl(this);
+}
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+AlfredUserConfigurationNumberSlider
+    _$AlfredUserConfigurationNumberSliderFromJson(Map<String, dynamic> json) =>
+        AlfredUserConfigurationNumberSlider(
+          type: $enumDecode(_$AlfredUserConfigurationTypeEnumMap, json['type']),
+          variable: json['variable'] as String,
+          config: AlfredUserConfigurationNumberSlider._configFromJson(
+              json['config'] as Map),
+          description: json['description'] as String?,
+          label: json['label'] as String?,
+        );
+
+const _$AlfredUserConfigurationTypeEnumMap = {
+  AlfredUserConfigurationType.textField: 'textfield',
+  AlfredUserConfigurationType.textArea: 'textarea',
+  AlfredUserConfigurationType.checkBox: 'checkbox',
+  AlfredUserConfigurationType.select: 'popupbutton',
+  AlfredUserConfigurationType.filePicker: 'filepicker',
+  AlfredUserConfigurationType.slider: 'slider',
+};

--- a/lib/src/models/alfred_user_configuration_select.dart
+++ b/lib/src/models/alfred_user_configuration_select.dart
@@ -14,7 +14,7 @@ part 'alfred_user_configuration_select.g.dart';
 @CopyWith()
 @JsonSerializable(explicitToJson: true, createToJson: false)
 final class AlfredUserConfigurationSelect
-    extends AlfredUserConfiguration<AlfredUserConfigurationConfigSelect>
+    extends AlfredUserConfiguration<String, AlfredUserConfigurationConfigSelect>
     with EquatableMixin {
   const AlfredUserConfigurationSelect({
     required super.type,
@@ -31,9 +31,9 @@ final class AlfredUserConfigurationSelect
 
   @internal
   @override
-  AlfredUserConfiguration<AlfredUserConfigurationConfigSelect> copyWithConfig(
-          AlfredUserConfigurationConfigSelect config) =>
-      copyWith(config: config);
+  AlfredUserConfiguration<String, AlfredUserConfigurationConfigSelect>
+      copyWithConfig(AlfredUserConfigurationConfigSelect config) =>
+          copyWith(config: config);
 
   static AlfredUserConfigurationConfigSelect _configFromJson(Map json) =>
       AlfredUserConfigurationConfigSelect.fromJson(

--- a/lib/src/models/alfred_user_configuration_select.g.dart
+++ b/lib/src/models/alfred_user_configuration_select.g.dart
@@ -129,4 +129,5 @@ const _$AlfredUserConfigurationTypeEnumMap = {
   AlfredUserConfigurationType.checkBox: 'checkbox',
   AlfredUserConfigurationType.select: 'popupbutton',
   AlfredUserConfigurationType.filePicker: 'filepicker',
+  AlfredUserConfigurationType.slider: 'slider',
 };

--- a/lib/src/models/alfred_user_configuration_text_area.dart
+++ b/lib/src/models/alfred_user_configuration_text_area.dart
@@ -13,9 +13,8 @@ part 'alfred_user_configuration_text_area.g.dart';
 @autoequal
 @CopyWith()
 @JsonSerializable(explicitToJson: true, createToJson: false)
-final class AlfredUserConfigurationTextArea
-    extends AlfredUserConfiguration<AlfredUserConfigurationConfigTextArea>
-    with EquatableMixin {
+final class AlfredUserConfigurationTextArea extends AlfredUserConfiguration<
+    String, AlfredUserConfigurationConfigTextArea> with EquatableMixin {
   const AlfredUserConfigurationTextArea({
     required super.type,
     required super.variable,
@@ -31,9 +30,9 @@ final class AlfredUserConfigurationTextArea
 
   @internal
   @override
-  AlfredUserConfiguration<AlfredUserConfigurationConfigTextArea> copyWithConfig(
-          AlfredUserConfigurationConfigTextArea config) =>
-      copyWith(config: config);
+  AlfredUserConfiguration<String, AlfredUserConfigurationConfigTextArea>
+      copyWithConfig(AlfredUserConfigurationConfigTextArea config) =>
+          copyWith(config: config);
 
   static AlfredUserConfigurationConfigTextArea _configFromJson(Map json) =>
       AlfredUserConfigurationConfigTextArea.fromJson(

--- a/lib/src/models/alfred_user_configuration_text_area.g.dart
+++ b/lib/src/models/alfred_user_configuration_text_area.g.dart
@@ -129,4 +129,5 @@ const _$AlfredUserConfigurationTypeEnumMap = {
   AlfredUserConfigurationType.checkBox: 'checkbox',
   AlfredUserConfigurationType.select: 'popupbutton',
   AlfredUserConfigurationType.filePicker: 'filepicker',
+  AlfredUserConfigurationType.slider: 'slider',
 };

--- a/lib/src/models/alfred_user_configuration_text_field.dart
+++ b/lib/src/models/alfred_user_configuration_text_field.dart
@@ -13,9 +13,8 @@ part 'alfred_user_configuration_text_field.g.dart';
 @autoequal
 @CopyWith()
 @JsonSerializable(explicitToJson: true, createToJson: false)
-final class AlfredUserConfigurationTextField
-    extends AlfredUserConfiguration<AlfredUserConfigurationConfigTextField>
-    with EquatableMixin {
+final class AlfredUserConfigurationTextField extends AlfredUserConfiguration<
+    String, AlfredUserConfigurationConfigTextField> with EquatableMixin {
   const AlfredUserConfigurationTextField({
     required super.type,
     required super.variable,
@@ -31,7 +30,7 @@ final class AlfredUserConfigurationTextField
 
   @internal
   @override
-  AlfredUserConfiguration<AlfredUserConfigurationConfigTextField>
+  AlfredUserConfiguration<String, AlfredUserConfigurationConfigTextField>
       copyWithConfig(AlfredUserConfigurationConfigTextField config) =>
           copyWith(config: config);
 

--- a/lib/src/models/alfred_user_configuration_text_field.g.dart
+++ b/lib/src/models/alfred_user_configuration_text_field.g.dart
@@ -129,4 +129,5 @@ const _$AlfredUserConfigurationTypeEnumMap = {
   AlfredUserConfigurationType.checkBox: 'checkbox',
   AlfredUserConfigurationType.select: 'popupbutton',
   AlfredUserConfigurationType.filePicker: 'filepicker',
+  AlfredUserConfigurationType.slider: 'slider',
 };

--- a/lib/src/models/alfred_user_configuration_type.dart
+++ b/lib/src/models/alfred_user_configuration_type.dart
@@ -11,7 +11,9 @@ enum AlfredUserConfigurationType {
   @JsonValue('popupbutton')
   select('popupbutton'),
   @JsonValue('filepicker')
-  filePicker('filepicker');
+  filePicker('filepicker'),
+  @JsonValue('slider')
+  slider('slider');
 
   const AlfredUserConfigurationType(this.jsonValue);
 

--- a/lib/src/models/index.dart
+++ b/lib/src/models/index.dart
@@ -12,6 +12,7 @@ export 'alfred_user_configuration_config_file_picker.dart';
 export 'alfred_user_configuration_config_select.dart';
 export 'alfred_user_configuration_config_text_area.dart';
 export 'alfred_user_configuration_config_text_field.dart';
+export 'alfred_user_configuration_number_slider.dart';
 export 'alfred_user_configuration_file_picker.dart';
 export 'alfred_user_configuration_select.dart';
 export 'alfred_user_configuration_text_area.dart';

--- a/test/fixtures/data/info.plist
+++ b/test/fixtures/data/info.plist
@@ -120,6 +120,31 @@
 			<key>variable</key>
 			<string>filepicker_variable</string>
 		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>defaultvalue</key>
+				<integer>50</integer>
+				<key>markercount</key>
+				<integer>10</integer>
+				<key>maxvalue</key>
+				<integer>100</integer>
+				<key>minvalue</key>
+				<integer>0</integer>
+				<key>onlystoponmarkers</key>
+				<true/>
+				<key>showmarkers</key>
+				<true/>
+			</dict>
+			<key>description</key>
+			<string>number slider description</string>
+			<key>label</key>
+			<string>number slider label</string>
+			<key>type</key>
+			<string>slider</string>
+			<key>variable</key>
+			<string>number_slider_variable</string>
+		</dict>
 	</array>
 </dict>
 </plist>

--- a/test/fixtures/data/prefs.plist
+++ b/test/fixtures/data/prefs.plist
@@ -14,5 +14,7 @@
 	<string></string>
 	<key>textarea_variable</key>
 	<string>lorem ipsum dolor sit amet</string>
+	<key>number_slider_variable</key>
+	<integer>69</integer>
 </dict>
 </plist>

--- a/test/unit/extensions/user_defaults_test.dart
+++ b/test/unit/extensions/user_defaults_test.dart
@@ -32,6 +32,8 @@ void main() {
             isA<AlfredUserConfigurationConfigTextArea>(),
           );
           expect(defaultItem.config.defaultValue, equals('textarea default'));
+          expect(defaultItem.defaultValue,
+              equals(defaultItem.config.defaultValue));
           expect(defaultItem.config.required, isTrue);
           expect(defaultItem.config.trim, isFalse);
           expect(defaultItem.config.verticalSize, equals(3));
@@ -48,6 +50,8 @@ void main() {
             isA<AlfredUserConfigurationConfigTextField>(),
           );
           expect(defaultItem.config.defaultValue, equals('textfield default'));
+          expect(defaultItem.defaultValue,
+              equals(defaultItem.config.defaultValue));
           expect(
             defaultItem.config.placeholder,
             equals('textfield placeholder'),
@@ -69,6 +73,8 @@ void main() {
             isA<AlfredUserConfigurationConfigCheckBox>(),
           );
           expect(defaultItem.config.defaultValue, isFalse);
+          expect(defaultItem.defaultValue,
+              equals(defaultItem.config.defaultValue));
           expect(defaultItem.config.required, isTrue);
           expect(defaultItem.config.text, equals('checkbox text'));
           expect(defaultItem.description, equals('checkbox description'));
@@ -86,6 +92,8 @@ void main() {
             isA<AlfredUserConfigurationConfigSelect>(),
           );
           expect(defaultItem.config.defaultValue, equals('baz value'));
+          expect(defaultItem.defaultValue,
+              equals(defaultItem.config.defaultValue));
           expect(defaultItem.config.pairs,
               isA<List<AlfredUserConfigurationConfigSelectPair>>());
           expect(defaultItem.config.pairs, isNotEmpty);
@@ -114,6 +122,8 @@ void main() {
           expect(defaultItem.config,
               isA<AlfredUserConfigurationConfigFilePicker>());
           expect(defaultItem.config.defaultValue, isEmpty);
+          expect(defaultItem.defaultValue,
+              equals(defaultItem.config.defaultValue));
           expect(defaultItem.config.required, isTrue);
           expect(defaultItem.config.placeholder, isEmpty);
           expect(defaultItem.config.filterMode, equals(0));
@@ -143,6 +153,8 @@ void main() {
             isA<AlfredUserConfigurationConfigTextArea>(),
           );
           expect(defaultItem.config.defaultValue, equals('textarea default'));
+          expect(defaultItem.defaultValue,
+              equals(defaultItem.config.defaultValue));
           expect(defaultItem.config.required, isTrue);
           expect(defaultItem.config.trim, isFalse);
           expect(defaultItem.config.verticalSize, equals(3));
@@ -159,6 +171,8 @@ void main() {
             isA<AlfredUserConfigurationConfigTextField>(),
           );
           expect(defaultItem.config.defaultValue, equals('textfield default'));
+          expect(defaultItem.defaultValue,
+              equals(defaultItem.config.defaultValue));
           expect(
             defaultItem.config.placeholder,
             equals('textfield placeholder'),
@@ -180,6 +194,8 @@ void main() {
             isA<AlfredUserConfigurationConfigCheckBox>(),
           );
           expect(defaultItem.config.defaultValue, isFalse);
+          expect(defaultItem.defaultValue,
+              equals(defaultItem.config.defaultValue));
           expect(defaultItem.config.required, isTrue);
           expect(defaultItem.config.text, equals('checkbox text'));
           expect(defaultItem.description, equals('checkbox description'));
@@ -197,6 +213,8 @@ void main() {
             isA<AlfredUserConfigurationConfigSelect>(),
           );
           expect(defaultItem.config.defaultValue, equals('baz value'));
+          expect(defaultItem.defaultValue,
+              equals(defaultItem.config.defaultValue));
           expect(defaultItem.config.pairs,
               isA<List<AlfredUserConfigurationConfigSelectPair>>());
           expect(defaultItem.config.pairs, isNotEmpty);
@@ -225,6 +243,8 @@ void main() {
           expect(defaultItem.config,
               isA<AlfredUserConfigurationConfigFilePicker>());
           expect(defaultItem.config.defaultValue, isEmpty);
+          expect(defaultItem.defaultValue,
+              equals(defaultItem.config.defaultValue));
           expect(defaultItem.config.required, isTrue);
           expect(defaultItem.config.placeholder, isEmpty);
           expect(defaultItem.config.filterMode, equals(0));
@@ -243,6 +263,8 @@ void main() {
             isA<AlfredUserConfigurationConfigNumberSlider>(),
           );
           expect(defaultItem.config.defaultValue, equals(50));
+          expect(defaultItem.defaultValue,
+              equals(defaultItem.config.defaultValue));
           expect(defaultItem.config.min, equals(0));
           expect(defaultItem.config.max, equals(100));
           expect(defaultItem.config.markerCount, equals(10));
@@ -292,6 +314,8 @@ void main() {
           );
           expect(defaultItem.config.value, 'lorem ipsum dolor sit amet');
           expect(defaultItem.config.defaultValue, equals('textarea default'));
+          expect(defaultItem.defaultValue,
+              equals(defaultItem.config.defaultValue));
           expect(defaultItem.config.required, isTrue);
           expect(defaultItem.config.trim, isFalse);
           expect(defaultItem.config.verticalSize, equals(3));
@@ -309,6 +333,8 @@ void main() {
           );
           expect(defaultItem.config.value, 'lorem ipsum dolor');
           expect(defaultItem.config.defaultValue, equals('textfield default'));
+          expect(defaultItem.defaultValue,
+              equals(defaultItem.config.defaultValue));
           expect(
             defaultItem.config.placeholder,
             equals('textfield placeholder'),
@@ -331,6 +357,8 @@ void main() {
           );
           expect(defaultItem.config.value, isTrue);
           expect(defaultItem.config.defaultValue, isFalse);
+          expect(defaultItem.defaultValue,
+              equals(defaultItem.config.defaultValue));
           expect(defaultItem.config.required, isTrue);
           expect(defaultItem.config.text, equals('checkbox text'));
           expect(defaultItem.description, equals('checkbox description'));
@@ -349,6 +377,8 @@ void main() {
           );
           expect(defaultItem.config.value, equals('foo value'));
           expect(defaultItem.config.defaultValue, equals('baz value'));
+          expect(defaultItem.defaultValue,
+              equals(defaultItem.config.defaultValue));
           expect(defaultItem.config.pairs,
               isA<List<AlfredUserConfigurationConfigSelectPair>>());
           expect(defaultItem.config.pairs, isNotEmpty);
@@ -376,13 +406,40 @@ void main() {
           expect(defaultItem.variable, equals('filepicker_variable'));
           expect(defaultItem.config,
               isA<AlfredUserConfigurationConfigFilePicker>());
-          expect(defaultItem.config.value, '/home/user/Desktop/document.pdf');
+          expect(defaultItem.config.value,
+              equals('/home/user/Desktop/document.pdf'));
           expect(defaultItem.config.defaultValue, isEmpty);
+          expect(defaultItem.defaultValue,
+              equals(defaultItem.config.defaultValue));
           expect(defaultItem.config.required, isTrue);
           expect(defaultItem.config.placeholder, isEmpty);
           expect(defaultItem.config.filterMode, equals(0));
           expect(defaultItem.description, equals('filepicker description'));
           expect(defaultItem.label, equals('filepicker label'));
+        }
+
+        if (defaultItem is AlfredUserConfigurationNumberSlider) {
+          expect(
+            defaultItem.type,
+            equals(AlfredUserConfigurationType.slider),
+          );
+          expect(defaultItem.variable, equals('number_slider_variable'));
+          expect(
+            defaultItem.config,
+            isA<AlfredUserConfigurationConfigNumberSlider>(),
+          );
+          expect(defaultItem.config.value, equals(69));
+          expect(defaultItem.value, equals(defaultItem.config.value));
+          expect(defaultItem.config.defaultValue, equals(50));
+          expect(defaultItem.defaultValue,
+              equals(defaultItem.config.defaultValue));
+          expect(defaultItem.config.min, equals(0));
+          expect(defaultItem.config.max, equals(100));
+          expect(defaultItem.config.markerCount, equals(10));
+          expect(defaultItem.config.onlyStopOnMarkers, isTrue);
+          expect(defaultItem.config.showMarkers, isTrue);
+          expect(defaultItem.description, equals('number slider description'));
+          expect(defaultItem.label, equals('number slider label'));
         }
       });
     });
@@ -418,6 +475,8 @@ void main() {
           );
           expect(defaultItem.config.value, 'lorem ipsum dolor sit amet');
           expect(defaultItem.config.defaultValue, equals('textarea default'));
+          expect(defaultItem.defaultValue,
+              equals(defaultItem.config.defaultValue));
           expect(defaultItem.config.required, isTrue);
           expect(defaultItem.config.trim, isFalse);
           expect(defaultItem.config.verticalSize, equals(3));
@@ -435,6 +494,8 @@ void main() {
           );
           expect(defaultItem.config.value, 'lorem ipsum dolor');
           expect(defaultItem.config.defaultValue, equals('textfield default'));
+          expect(defaultItem.defaultValue,
+              equals(defaultItem.config.defaultValue));
           expect(
             defaultItem.config.placeholder,
             equals('textfield placeholder'),
@@ -457,6 +518,8 @@ void main() {
           );
           expect(defaultItem.config.value, isTrue);
           expect(defaultItem.config.defaultValue, isFalse);
+          expect(defaultItem.defaultValue,
+              equals(defaultItem.config.defaultValue));
           expect(defaultItem.config.required, isTrue);
           expect(defaultItem.config.text, equals('checkbox text'));
           expect(defaultItem.description, equals('checkbox description'));
@@ -475,6 +538,8 @@ void main() {
           );
           expect(defaultItem.config.value, equals('foo value'));
           expect(defaultItem.config.defaultValue, equals('baz value'));
+          expect(defaultItem.defaultValue,
+              equals(defaultItem.config.defaultValue));
           expect(defaultItem.config.pairs,
               isA<List<AlfredUserConfigurationConfigSelectPair>>());
           expect(defaultItem.config.pairs, isNotEmpty);
@@ -502,13 +567,40 @@ void main() {
           expect(defaultItem.variable, equals('filepicker_variable'));
           expect(defaultItem.config,
               isA<AlfredUserConfigurationConfigFilePicker>());
-          expect(defaultItem.config.value, '/home/user/Desktop/document.pdf');
+          expect(defaultItem.config.value,
+              equals('/home/user/Desktop/document.pdf'));
           expect(defaultItem.config.defaultValue, isEmpty);
+          expect(defaultItem.defaultValue,
+              equals(defaultItem.config.defaultValue));
           expect(defaultItem.config.required, isTrue);
           expect(defaultItem.config.placeholder, isEmpty);
           expect(defaultItem.config.filterMode, equals(0));
           expect(defaultItem.description, equals('filepicker description'));
           expect(defaultItem.label, equals('filepicker label'));
+        }
+
+        if (defaultItem is AlfredUserConfigurationNumberSlider) {
+          expect(
+            defaultItem.type,
+            equals(AlfredUserConfigurationType.slider),
+          );
+          expect(defaultItem.variable, equals('number_slider_variable'));
+          expect(
+            defaultItem.config,
+            isA<AlfredUserConfigurationConfigNumberSlider>(),
+          );
+          expect(defaultItem.config.value, equals(69));
+          expect(defaultItem.value, equals(defaultItem.config.value));
+          expect(defaultItem.config.defaultValue, equals(50));
+          expect(defaultItem.defaultValue,
+              equals(defaultItem.config.defaultValue));
+          expect(defaultItem.config.min, equals(0));
+          expect(defaultItem.config.max, equals(100));
+          expect(defaultItem.config.markerCount, equals(10));
+          expect(defaultItem.config.onlyStopOnMarkers, isTrue);
+          expect(defaultItem.config.showMarkers, isTrue);
+          expect(defaultItem.description, equals('number slider description'));
+          expect(defaultItem.label, equals('number slider label'));
         }
       });
     });

--- a/test/unit/extensions/user_defaults_test.dart
+++ b/test/unit/extensions/user_defaults_test.dart
@@ -1,4 +1,5 @@
 import 'package:alfred_workflow/alfred_workflow.dart';
+import 'package:alfred_workflow/src/models/alfred_user_configuration_config_number_slider.dart';
 import 'package:test/test.dart';
 
 import '../../fixtures/alfred_workflow_fixture.dart';
@@ -229,6 +230,26 @@ void main() {
           expect(defaultItem.config.filterMode, equals(0));
           expect(defaultItem.description, equals('filepicker description'));
           expect(defaultItem.label, equals('filepicker label'));
+        }
+
+        if (defaultItem is AlfredUserConfigurationNumberSlider) {
+          expect(
+            defaultItem.type,
+            equals(AlfredUserConfigurationType.slider),
+          );
+          expect(defaultItem.variable, equals('number_slider_variable'));
+          expect(
+            defaultItem.config,
+            isA<AlfredUserConfigurationConfigNumberSlider>(),
+          );
+          expect(defaultItem.config.defaultValue, equals(50));
+          expect(defaultItem.config.min, equals(0));
+          expect(defaultItem.config.max, equals(100));
+          expect(defaultItem.config.markerCount, equals(10));
+          expect(defaultItem.config.onlyStopOnMarkers, isTrue);
+          expect(defaultItem.config.showMarkers, isTrue);
+          expect(defaultItem.description, equals('number slider description'));
+          expect(defaultItem.label, equals('number slider label'));
         }
       });
     });


### PR DESCRIPTION
This pull request introduces a new user configuration type, `AlfredUserConfigurationNumberSlider`, and updates related classes to support this new type. Key changes include modifications to existing configuration classes, the addition of new classes, and updates to JSON serialization.

### New Feature Addition

* Added `AlfredUserConfigurationNumberSlider` class to support integer slider configurations. This includes defining the class and its associated JSON serialization methods. (`lib/src/models/alfred_user_configuration_number_slider.dart`, `lib/src/models/alfred_user_configuration_number_slider.g.dart`) [[1]](diffhunk://#diff-2261dfb3143b0209e6196ba1571524745516713a0424075efd5292eb59ba2289R1-R46) [[2]](diffhunk://#diff-36710c25c24e71f4953c093ad1cf42e4fe6dbf996cc57f0ff98e8ee12f5c5b6bR1-R66) [[3]](diffhunk://#diff-59c79bed066dc6e7df7d2c96c74f4faaf253602ea4e264a8a60e308f4c193cdfR1-R150)

### Updates to Existing Classes

* Modified `AlfredUserConfiguration` class to support the new configuration type by adding a generic parameter and updating methods accordingly. (`lib/src/models/alfred_user_configuration.dart`) [[1]](diffhunk://#diff-2e0160a8aa96ed7460b7bf906a0aa55b7c04718cf68894f03470901ca110e083L11-R12) [[2]](diffhunk://#diff-2e0160a8aa96ed7460b7bf906a0aa55b7c04718cf68894f03470901ca110e083L33-R42)
* Updated `AlfredUserConfigurationCheckBox` and `AlfredUserConfigurationFilePicker` classes to use the new generic parameter. (`lib/src/models/alfred_user_configuration_check_box.dart`, `lib/src/models/alfred_user_configuration_file_picker.dart`) [[1]](diffhunk://#diff-6a2204ba852503fd5cb01b68afa2ef973e0531289c7d7b6049152012e2e1b78eL17-R17) [[2]](diffhunk://#diff-6a2204ba852503fd5cb01b68afa2ef973e0531289c7d7b6049152012e2e1b78eL34-R35) [[3]](diffhunk://#diff-cf39751da55f1f5e3c439843ba0734a6b47fe3688c9bbf933f8a2b2427cca2daL16-R17) [[4]](diffhunk://#diff-cf39751da55f1f5e3c439843ba0734a6b47fe3688c9bbf933f8a2b2427cca2daL34-R33)

### JSON Serialization Updates

* Added `slider` to the `AlfredUserConfigurationTypeEnumMap` for JSON serialization. (`lib/src/models/alfred_user_configuration_check_box.g.dart`, `lib/src/models/alfred_user_configuration_file_picker.g.dart`) [[1]](diffhunk://#diff-da953de8954712bc96c0dd94ab3d128dfdf94d86828a1adcb731b1650892c282R132) [[2]](diffhunk://#diff-c2e509ca7d0879c4888efd8821f530bef2ed0fd74c245d7016e4c13616694b45R132)
* Updated JSON deserialization methods to use `fromJsonDefaultValue` for default values. (`lib/src/models/alfred_user_configuration_config.dart`, `lib/src/models/alfred_user_configuration_config_check_box.g.dart`, `lib/src/models/alfred_user_configuration_config_file_picker.g.dart`, `lib/src/models/alfred_user_configuration_config_select.g.dart`, `lib/src/models/alfred_user_configuration_config_text_area.g.dart`, `lib/src/models/alfred_user_configuration_config_text_field.g.dart`) [[1]](diffhunk://#diff-38187052699a949ae13ff64c2d2d3f8e75a7d41ac7168a2892d4faf2e4c38d9aL17-L24) [[2]](diffhunk://#diff-dc4a3258349f33d9a3150df90191601d2c18a45aa03811e6b96d2d3aa06e72c1L105-R106) [[3]](diffhunk://#diff-d18e24a80b2c909f2d04c518934f493869f20f013a0b65a7af6427b94bc86d8dL118-R119) [[4]](diffhunk://#diff-ee41e73b2378011e5b51e6ddbece60a45025ff9c5f5f58f355de82d258269db2L95-R96) [[5]](diffhunk://#diff-1bd8e3d9f73eb5eae313c2fe543c5ff40c351791e932e5164bdcbf82e0ea8f53L117-R118) [[6]](diffhunk://#diff-3922ee3a8bcd046b3885fb87a85cbd3d0f55d68262daef41c7549fcf1ac85d4eL117-R118)

### Extension Updates

* Extended `UserDefaults` to handle the new slider configuration type. (`lib/src/extensions/user_defaults.dart`)