### PR TITLE
:zap: improve caching mechanism

### DIFF
--- a/test/fixtures/alfred_workflow_fixture.dart
+++ b/test/fixtures/alfred_workflow_fixture.dart
@@ -3,6 +3,7 @@ import 'package:data_fixture_dart/data_fixture_dart.dart';
 import 'package:meta/meta.dart';
 
 import '../helpers/mock_alfred_cache.dart';
+import 'models/alfred_automatic_cache_fixture.dart';
 
 extension AlfredWorkflowFixture on AlfredWorkflow {
   static AlfredWorkflowFactory get factory => AlfredWorkflowFactory();
@@ -11,14 +12,27 @@ extension AlfredWorkflowFixture on AlfredWorkflow {
 @internal
 final class AlfredWorkflowFactory extends FixtureFactory<AlfredWorkflow> {
   @override
-  FixtureDefinition<AlfredWorkflow> definition() => define(
-        (Faker faker) => AlfredWorkflow(
-          cache: MockAlfredCache<AlfredItems>(
-            fromEncodable: (Map<String, dynamic> json) =>
-                AlfredItems.fromJson(json),
-          ),
-        ),
-      );
+  FixtureDefinition<AlfredWorkflow> definition() =>
+      define((Faker faker) => AlfredWorkflow());
+
+  FixtureRedefinitionBuilder<AlfredWorkflow> withAutomaticCache(
+    AlfredAutomaticCache? automaticCache,
+  ) =>
+      (_) => AlfredWorkflow(
+            automaticCache: automaticCache ??
+                AlfredAutomaticCacheFixture.factory.makeSingle(),
+          );
+
+  FixtureRedefinitionBuilder<AlfredWorkflow> withFileCache(
+    AlfredCache<AlfredItems>? fileCache,
+  ) =>
+      (_) => AlfredWorkflow(
+            fileCache: fileCache ??
+                MockAlfredCache<AlfredItems>(
+                  fromEncodable: (Map<String, dynamic> json) =>
+                      AlfredItems.fromJson(json),
+                ),
+          );
 
   FixtureRedefinitionBuilder<AlfredWorkflow>
       withoutAlfredSmartResultOrdering() => (AlfredWorkflow workflow) =>

--- a/test/unit/alfred_workflow_test.dart
+++ b/test/unit/alfred_workflow_test.dart
@@ -110,8 +110,11 @@ void main() async {
           .redefine(AlfredItemsFixture.factory.withCache(automaticCache))
           .makeSingle();
 
-      workflow = AlfredWorkflowFixture.factory.makeSingle()
-        ..automaticCache = automaticCache;
+      workflow = AlfredWorkflowFixture.factory
+          .redefine(
+            AlfredWorkflowFixture.factory.withAutomaticCache(automaticCache),
+          )
+          .makeSingle();
     });
 
     test('getItems without adding anything is empty', () async {
@@ -420,37 +423,23 @@ void main() async {
       expect(workflow.cacheKey, isNotNull);
       expect(workflow.cacheKey, equals(cacheKey));
 
-      final AlfredAutomaticCache automaticCache = AlfredAutomaticCache(
-        seconds: faker.randomGenerator.integer(
-          AlfredAutomaticCache.maxSeconds,
-          min: AlfredAutomaticCache.minSeconds,
-        ),
-        looseReload: faker.randomGenerator.boolean(),
-      );
-      workflow.automaticCache = automaticCache;
+      workflow.useAutomaticCache = true;
 
       expect(workflow.cacheKey, isNull);
-      expect(workflow.automaticCache, isNotNull);
-      expect(workflow.automaticCache, equals(automaticCache));
+      expect(workflow.useAutomaticCache, isNotNull);
+      expect(workflow.useAutomaticCache, isTrue);
     });
 
     test('AlfredCache disables AlfredAutomaticCache', () {
-      final AlfredAutomaticCache automaticCache = AlfredAutomaticCache(
-        seconds: faker.randomGenerator.integer(
-          AlfredAutomaticCache.maxSeconds,
-          min: AlfredAutomaticCache.minSeconds,
-        ),
-        looseReload: faker.randomGenerator.boolean(),
-      );
-      workflow.automaticCache = automaticCache;
+      workflow.useAutomaticCache = true;
 
-      expect(workflow.automaticCache, isNotNull);
-      expect(workflow.automaticCache, equals(automaticCache));
+      expect(workflow.useAutomaticCache, isNotNull);
+      expect(workflow.useAutomaticCache, isTrue);
 
       final String cacheKey = faker.guid.guid();
       workflow.cacheKey = cacheKey;
 
-      expect(workflow.automaticCache, isNull);
+      expect(workflow.useAutomaticCache, isFalse);
       expect(workflow.cacheKey, isNotNull);
       expect(workflow.cacheKey, equals(cacheKey));
     });


### PR DESCRIPTION
This pull request introduces several changes to the `AlfredWorkflow` class to improve its caching mechanism and update the related tests. The most significant changes include the addition of a new `AlfredAutomaticCache`, updates to caching methods, and enhancements to the test fixtures and test cases.

### Caching Enhancements:

* [`lib/alfred_workflow.dart`](diffhunk://#diff-741ec5603a8b91be5b706d2cc07e60a4a341e8d37bc9c354e3cff66ee4fe4213L8-R8): Added `AlfredAutomaticCache` and updated the constructor to accept both `automaticCache` and `fileCache` options. Modified caching methods to use `_fileCache` instead of `_cache`. [[1]](diffhunk://#diff-741ec5603a8b91be5b706d2cc07e60a4a341e8d37bc9c354e3cff66ee4fe4213L8-R8) [[2]](diffhunk://#diff-741ec5603a8b91be5b706d2cc07e60a4a341e8d37bc9c354e3cff66ee4fe4213L22-R28) [[3]](diffhunk://#diff-741ec5603a8b91be5b706d2cc07e60a4a341e8d37bc9c354e3cff66ee4fe4213L45-R50) [[4]](diffhunk://#diff-741ec5603a8b91be5b706d2cc07e60a4a341e8d37bc9c354e3cff66ee4fe4213L59-R143) [[5]](diffhunk://#diff-741ec5603a8b91be5b706d2cc07e60a4a341e8d37bc9c354e3cff66ee4fe4213L98-R153) [[6]](diffhunk://#diff-741ec5603a8b91be5b706d2cc07e60a4a341e8d37bc9c354e3cff66ee4fe4213L114-R169) [[7]](diffhunk://#diff-741ec5603a8b91be5b706d2cc07e60a4a341e8d37bc9c354e3cff66ee4fe4213L134-R189) [[8]](diffhunk://#diff-741ec5603a8b91be5b706d2cc07e60a4a341e8d37bc9c354e3cff66ee4fe4213L150-R205)

### Test Fixtures:

* [`test/fixtures/alfred_workflow_fixture.dart`](diffhunk://#diff-09ce5f234389ee65a3bd808f6df08999b62c86de8e8bb683eb7ec158d1c2ace2R6): Added new fixture definitions to support `AlfredAutomaticCache` and `fileCache`. [[1]](diffhunk://#diff-09ce5f234389ee65a3bd808f6df08999b62c86de8e8bb683eb7ec158d1c2ace2R6) [[2]](diffhunk://#diff-09ce5f234389ee65a3bd808f6df08999b62c86de8e8bb683eb7ec158d1c2ace2L14-L20)

### Test Cases:

* [`test/unit/alfred_workflow_test.dart`](diffhunk://#diff-fa5c0af771421232f01fd16b83365244e5bb79e17fea0157e7cd2274f02f0f16L113-R117): Updated test cases to use the new `useAutomaticCache` property and modified the workflow setup to use the new fixture definitions. [[1]](diffhunk://#diff-fa5c0af771421232f01fd16b83365244e5bb79e17fea0157e7cd2274f02f0f16L113-R117) [[2]](diffhunk://#diff-fa5c0af771421232f01fd16b83365244e5bb79e17fea0157e7cd2274f02f0f16L423-R442)